### PR TITLE
Fix lightning bolts

### DIFF
--- a/src/main/java/org/cyclops/evilcraft/event/EntityStruckByLightningEventHook.java
+++ b/src/main/java/org/cyclops/evilcraft/event/EntityStruckByLightningEventHook.java
@@ -1,12 +1,16 @@
 package org.cyclops.evilcraft.event;
 
+import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.HashSet;
+import java.util.Set;
+
 import org.cyclops.evilcraft.Configs;
-import org.cyclops.evilcraft.entity.monster.WerewolfConfig;
 import org.cyclops.evilcraft.entity.villager.WerewolfVillager;
 import org.cyclops.evilcraft.entity.villager.WerewolfVillagerConfig;
 import org.cyclops.evilcraft.item.IItemEmpowerable;
@@ -23,7 +27,7 @@ public class EntityStruckByLightningEventHook {
      * @param event The received event.
      */
 	@SubscribeEvent(priority = EventPriority.NORMAL)
-    public void onLivingAttack(EntityStruckByLightningEvent event) {
+    public void onEntityStruckByLightning(EntityStruckByLightningEvent event) {
 		empowerItem(event);
 		transformVillager(event);
     }
@@ -42,13 +46,26 @@ public class EntityStruckByLightningEventHook {
         }
     }
     
+    private EntityLightningBolt lastLightningBolt;
+    private Set<EntityVillager> affectedVillagers;
+
     private void transformVillager(EntityStruckByLightningEvent event) {
-        if(Configs.isEnabled(WerewolfConfig.class) && Configs.isEnabled(WerewolfVillagerConfig.class)
-                && event.getEntity() instanceof EntityVillager) {
-        	EntityVillager entity = (EntityVillager) event.getEntity();
+        if(Configs.isEnabled(WerewolfVillagerConfig.class) && event.getEntity() instanceof EntityVillager) {
+            EntityVillager entity = (EntityVillager) event.getEntity();
+            if(lastLightningBolt != event.getLightning()) {
+                lastLightningBolt = event.getLightning();
+                affectedVillagers = new HashSet<>();
+            }
+            if(!affectedVillagers.add(entity)) {
+                // The same lightning bolt will strike multiple times. Only count the first time it hits any entity
+                event.setCanceled(true);
+                return;
+            }
             if(entity.getProfessionForge() != WerewolfVillager.getInstance()) {
             	entity.setProfession(WerewolfVillager.getInstance());
             }
+            if(entity.getWorld().rand.nextBoolean())
+                event.setCanceled(true); // 50% chance that they become a witch like vanilla does
         }
     }
     


### PR DESCRIPTION
Turning villagers into werewolvians never actually worked right, because in
vanilla, lightning turns villagers into witches, and it "wins". Rework it to
have a 50% chance of making them witches like vanilla, and a 50% chance of
making them werewolvians.