### PR TITLE
Don't always show vengeance spirits in creative mode

### DIFF
--- a/src/main/java/org/cyclops/evilcraft/entity/monster/VengeanceSpirit.java
+++ b/src/main/java/org/cyclops/evilcraft/entity/monster/VengeanceSpirit.java
@@ -384,7 +384,7 @@ public class VengeanceSpirit extends EntityNoMob implements IConfigurable {
     
     private boolean isAlternativelyVisible() {
         EntityPlayerSP player = Minecraft.getMinecraft().player;
-		return player != null && player.capabilities.isCreativeMode;
+		return VengeanceSpiritConfig.alwaysVisibleInCreative && player != null && player.capabilities.isCreativeMode;
 	}
 
     @Override

--- a/src/main/java/org/cyclops/evilcraft/entity/monster/VengeanceSpiritConfig.java
+++ b/src/main/java/org/cyclops/evilcraft/entity/monster/VengeanceSpiritConfig.java
@@ -61,6 +61,9 @@ VengeanceSpiritConfig extends MobConfig<VengeanceSpirit> {
         "intangible:soul",
     };
 
+    @ConfigurableProperty(category = ConfigurableTypeCategory.MOB, comment = "Whether vengeance spirits should always be visible in creative mode.")
+    public static boolean alwaysVisibleInCreative = false;
+
     /**
      * The 1/X chance that an actual spirit will spawn when doing actions like mining with the Vengeance Pickaxe.
      */

--- a/src/main/resources/assets/evilcraft/lang/en_us.lang
+++ b/src/main/resources/assets/evilcraft/lang/en_us.lang
@@ -967,6 +967,7 @@ config.evilcraft.vengeance_spirit.isEnabled=Vengeance Spirit
 config.evilcraft.vengeance_spirit.nonDegradedSpawnChance=Vengeance Spirit spawn chance on item use
 config.evilcraft.vengeance_spirit.spawnLimit=Vengeance Spirit spawn limit
 config.evilcraft.vengeance_spirit.spawnLimitArea=Vengeance Spirit spawn area limit
+config.evilcraft.vengeance_spirit.alwaysVisibleInCreative=Vengeance Spirits always visible in creative
 
 config.evilcraft.werewolf.isEnabled=Werewolf    
 


### PR DESCRIPTION
When this was originally added, spectral glasses didn't exist. Now that they
do, creative players can just get and use these to see spirits if they want.
Fixes #632.