### PR TITLE
Use static `LockableLootTileEntity::setLootTable` over direct tile manipulation

### DIFF
--- a/src/main/java/org/cyclops/evilcraft/world/gen/feature/WorldFeatureEvilDungeon.java
+++ b/src/main/java/org/cyclops/evilcraft/world/gen/feature/WorldFeatureEvilDungeon.java
@@ -119,6 +119,7 @@ public class WorldFeatureEvilDungeon extends DungeonsFeature {
 
                     if (wallCounter == 1) {
                         world.setBlockState(loopPos, Blocks.CHEST.getDefaultState(), MinecraftHelpers.BLOCK_NOTIFY_CLIENT);
+                         // Static method used instead of manual tile fetch -> member setLootTable to provide compatibility with Lootr.
                         LockableLootTileEntity.setLootTable(world, random, loopPos, LootTables.CHESTS_SIMPLE_DUNGEON);
 
                         chests--;

--- a/src/main/java/org/cyclops/evilcraft/world/gen/feature/WorldFeatureEvilDungeon.java
+++ b/src/main/java/org/cyclops/evilcraft/world/gen/feature/WorldFeatureEvilDungeon.java
@@ -5,6 +5,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.block.material.Material;
 import net.minecraft.loot.LootTables;
 import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.LockableLootTileEntity;
 import net.minecraft.tileentity.MobSpawnerTileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ISeedReader;
@@ -118,11 +119,7 @@ public class WorldFeatureEvilDungeon extends DungeonsFeature {
 
                     if (wallCounter == 1) {
                         world.setBlockState(loopPos, Blocks.CHEST.getDefaultState(), MinecraftHelpers.BLOCK_NOTIFY_CLIENT);
-                        ChestTileEntity tileentitychest = (ChestTileEntity)world.getTileEntity(loopPos);
-
-                        if (tileentitychest != null) {
-                            tileentitychest.setLootTable(LootTables.CHESTS_SIMPLE_DUNGEON, random.nextLong());
-                        }
+                        LockableLootTileEntity.setLootTable(world, random, loopPos, LootTables.CHESTS_SIMPLE_DUNGEON);
 
                         chests--;
                     }

--- a/src/main/java/org/cyclops/evilcraft/world/gen/structure/WorldStructureDarkTemple.java
+++ b/src/main/java/org/cyclops/evilcraft/world/gen/structure/WorldStructureDarkTemple.java
@@ -114,6 +114,7 @@ public class WorldStructureDarkTemple extends Structure<NoFeatureConfig> {
             BlockWrapper lc = new BlockWrapper(Blocks.CHEST.getDefaultState(), (float) GeneralConfig.darkTempleChestChance);
             lc.action = (world, pos) -> {
                 Random rand = new Random();
+                // Static method used instead of manual tile fetch -> member setLootTable to provide compatibility with Lootr.
                 LockableLootTileEntity.setLootTable(world, rand, pos, LootTables.CHESTS_JUNGLE_TEMPLE);
             };
             BlockWrapper vi = new BlockWrapper(Blocks.VINE.getDefaultState(), 0.3F);

--- a/src/main/java/org/cyclops/evilcraft/world/gen/structure/WorldStructureDarkTemple.java
+++ b/src/main/java/org/cyclops/evilcraft/world/gen/structure/WorldStructureDarkTemple.java
@@ -13,6 +13,7 @@ import net.minecraft.state.properties.Half;
 import net.minecraft.state.properties.SlabType;
 import net.minecraft.state.properties.StairsShape;
 import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.LockableLootTileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.SharedSeedRandom;
 import net.minecraft.util.math.BlockPos;
@@ -113,10 +114,7 @@ public class WorldStructureDarkTemple extends Structure<NoFeatureConfig> {
             BlockWrapper lc = new BlockWrapper(Blocks.CHEST.getDefaultState(), (float) GeneralConfig.darkTempleChestChance);
             lc.action = (world, pos) -> {
                 Random rand = new Random();
-                ChestTileEntity tile = (ChestTileEntity) world.getTileEntity(pos);
-                if (tile != null) {
-                    tile.setLootTable(LootTables.CHESTS_JUNGLE_TEMPLE, rand.nextLong());
-                }
+                LockableLootTileEntity.setLootTable(world, rand, pos, LootTables.CHESTS_JUNGLE_TEMPLE);
             };
             BlockWrapper vi = new BlockWrapper(Blocks.VINE.getDefaultState(), 0.3F);
             vi.action = (world, pos) -> {


### PR DESCRIPTION
This allows for compatibility with the mod Lootr, which hooks directly into the static method instead. It's not possible for Lootr to hook into the non-static method as it's generally called during world generation and the tile entity lacks information in order to change itself.

Functionally there's no difference between the two, and if anything this version makes the code cleaner.