### PR TITLE
Fix a bug that villagers will not turn to witches on struck by lightning.

### DIFF
--- a/src/main/java/org/cyclops/evilcraft/event/EntityStruckByLightningEventHook.java
+++ b/src/main/java/org/cyclops/evilcraft/event/EntityStruckByLightningEventHook.java
@@ -60,11 +60,13 @@ public class EntityStruckByLightningEventHook {
                 event.setCanceled(true);
                 return;
             }
+            if(entity.level().random.nextBoolean()) {
+                event.setCanceled(true); // 50% chance that they become a witch like vanilla does
+                return;
+            }
             if(entity.getVillagerData().getProfession() != RegistryEntries.VILLAGER_PROFESSION_WEREWOLF) {
                 EntityWerewolf.initializeWerewolfVillagerData(entity);
             }
-            if(entity.level().random.nextBoolean())
-                event.setCanceled(true); // 50% chance that they become a witch like vanilla does
         }
     }
 


### PR DESCRIPTION
The original lightning converts a villager to a werewolf before checking 50% probability. This will cause lightnings to convert villagers to werewolves by 100% instead of 50%.