### PR TITLE
Fix eternal_water.json to use  the right c tag

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/data/evilcraft/recipe/crafting/eternal_water.json
+++ b/src/main/resources/data/evilcraft/recipe/crafting/eternal_water.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "G": {
-      "tag": "c:glass_blocks_panes"
+      "tag": "c:glass_blocks"
     },
     "W": {
       "type": "neoforge:components",


### PR DESCRIPTION
Currently, c:glass_blocks_panes is being used but doesn't exist, therefore it has been changed to c:glass_blocks to fix the issue when trying to craft the block.