### PR TITLE
fixed eternal_water.json

### DIFF
--- a/src/main/resources/data/evilcraft/recipe/crafting/eternal_water.json
+++ b/src/main/resources/data/evilcraft/recipe/crafting/eternal_water.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "G": {
-      "tag": "c:glass_blocks_panes"
+      "tag": "c:glass_blocks"
     },
     "W": {
       "type": "neoforge:components",

--- a/src/main/resources/data/evilcraft/recipe/crafting/eternal_water.json
+++ b/src/main/resources/data/evilcraft/recipe/crafting/eternal_water.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "G": {
-      "tag": "c:glass_blocks"
+      "tag": "c:glass_panes"
     },
     "W": {
       "type": "neoforge:components",


### PR DESCRIPTION
This changed the tag to the right one being used, as before it used one none existent.