### PR TITLE
Handle NoSuchElementException in BoxCookTickAction.java

### DIFF
--- a/src/main/java/org/cyclops/evilcraft/blockentity/tickaction/spiritfurnace/BoxCookTickAction.java
+++ b/src/main/java/org/cyclops/evilcraft/blockentity/tickaction/spiritfurnace/BoxCookTickAction.java
@@ -50,6 +50,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.NoSuchElementException;
 
 /**
  * {@link ITickAction} that is able to cook boxes with spirits.
@@ -153,7 +154,7 @@ public class BoxCookTickAction implements ITickAction<BlockEntitySpiritFurnace> 
         ItemStack itemStack = new ItemStack(Items.PLAYER_HEAD);
         try {
             itemStack.set(DataComponents.PROFILE, new ResolvableProfile(SkullBlockEntity.fetchGameProfile(playerName).get(1, TimeUnit.SECONDS).get()));
-        } catch (InterruptedException | ExecutionException | NullPointerException | TimeoutException e) {
+        } catch (InterruptedException | ExecutionException | NullPointerException | TimeoutException | 	NoSuchElementException e) {
             e.printStackTrace();
         }
         return itemStack;

--- a/src/main/java/org/cyclops/evilcraft/blockentity/tickaction/spiritfurnace/BoxCookTickAction.java
+++ b/src/main/java/org/cyclops/evilcraft/blockentity/tickaction/spiritfurnace/BoxCookTickAction.java
@@ -154,7 +154,7 @@ public class BoxCookTickAction implements ITickAction<BlockEntitySpiritFurnace> 
         ItemStack itemStack = new ItemStack(Items.PLAYER_HEAD);
         try {
             itemStack.set(DataComponents.PROFILE, new ResolvableProfile(SkullBlockEntity.fetchGameProfile(playerName).get(1, TimeUnit.SECONDS).get()));
-        } catch (InterruptedException | ExecutionException | NullPointerException | TimeoutException | 	NoSuchElementException e) {
+        } catch (InterruptedException | ExecutionException | NullPointerException | TimeoutException | NoSuchElementException e) {
             e.printStackTrace();
         }
         return itemStack;


### PR DESCRIPTION
Adds the NoSuchElementException to the list of catches to avoid issues, fixes #1085