### PR TITLE
Give maces a configurable attack speed

### DIFF
--- a/src/main/java/org/cyclops/evilcraft/item/ItemMace.java
+++ b/src/main/java/org/cyclops/evilcraft/item/ItemMace.java
@@ -260,13 +260,22 @@ public abstract class ItemMace extends ItemBloodContainer {
     }
 
     @Override
-    public Multimap<Attribute, AttributeModifier> getAttributeModifiers(EquipmentSlot slot, ItemStack itemStack) {
+    public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot slot) {
         if (slot == EquipmentSlot.MAINHAND) {
-            return ImmutableMultimap.of(Attributes.ATTACK_DAMAGE,
-                    new AttributeModifier(BASE_ATTACK_DAMAGE_UUID, "Weapon modifier", this.meleeDamage, AttributeModifier.Operation.ADDITION));
+            return ImmutableMultimap.of(
+                    Attributes.ATTACK_DAMAGE,
+                    new AttributeModifier(BASE_ATTACK_DAMAGE_UUID, "Weapon modifier", this.meleeDamage, AttributeModifier.Operation.ADDITION),
+                    Attributes.ATTACK_SPEED,
+                    new AttributeModifier(BASE_ATTACK_SPEED_UUID, "Weapon modifier", getAttackSpeed(), AttributeModifier.Operation.ADDITION));
         }
-        return super.getAttributeModifiers(slot, itemStack);
+        return super.getDefaultAttributeModifiers(slot);
     }
+
+    /**
+     * @return The attack speed modifier of this mace,
+     *         which is added to the default player attack speed of 4.
+     */
+    protected abstract float getAttackSpeed();
 
     @OnlyIn(Dist.CLIENT)
     @Override

--- a/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDestruction.java
+++ b/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDestruction.java
@@ -29,6 +29,11 @@ public class ItemMaceOfDestruction extends ItemMace {
     }
 
     @Override
+    protected float getAttackSpeed() {
+        return (float) ItemMaceOfDestructionConfig.attackSpeed;
+    }
+
+    @Override
     protected void use(Level world, LivingEntity entity, int itemUsedCount, int power) {
         if(!world.isClientSide()) {
             Vec3 v = entity.getLookAngle();

--- a/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDestructionConfig.java
+++ b/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDestructionConfig.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 public class ItemMaceOfDestructionConfig extends ItemConfig {
 
     @ConfigurableProperty(category = "item", comment = "The attack speed modifier of this mace, which is added to the default player attack speed of 4.", isCommandable = true)
-    public static double attackSpeed = -3.2;
+    public static double attackSpeed = -3.0;
 
     public ItemMaceOfDestructionConfig() {
         super(

--- a/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDestructionConfig.java
+++ b/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDestructionConfig.java
@@ -2,6 +2,7 @@ package org.cyclops.evilcraft.item;
 
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import org.cyclops.cyclopscore.config.ConfigurableProperty;
 import org.cyclops.cyclopscore.config.extendedconfig.ItemConfig;
 import org.cyclops.evilcraft.EvilCraft;
 
@@ -13,6 +14,9 @@ import java.util.Collection;
  *
  */
 public class ItemMaceOfDestructionConfig extends ItemConfig {
+
+    @ConfigurableProperty(category = "item", comment = "The attack speed modifier of this mace, which is added to the default player attack speed of 4.", isCommandable = true)
+    public static double attackSpeed = -3.2;
 
     public ItemMaceOfDestructionConfig() {
         super(

--- a/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDistortion.java
+++ b/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDistortion.java
@@ -1,7 +1,5 @@
 package org.cyclops.evilcraft.item;
 
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
@@ -9,11 +7,7 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.ai.attributes.Attribute;
-import net.minecraft.world.entity.ai.attributes.AttributeModifier;
-import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -167,12 +161,8 @@ public class ItemMaceOfDistortion extends ItemMace {
     }
 
     @Override
-    public Multimap<Attribute, AttributeModifier> getAttributeModifiers(EquipmentSlot slot, ItemStack itemStack) {
-        if (slot == EquipmentSlot.MAINHAND) {
-            return ImmutableMultimap.of(Attributes.ATTACK_DAMAGE,
-                    new AttributeModifier(BASE_ATTACK_DAMAGE_UUID, "Weapon modifier", MELEE_DAMAGE, AttributeModifier.Operation.ADDITION));
-        }
-        return super.getAttributeModifiers(slot, itemStack);
+    protected float getAttackSpeed() {
+        return (float) ItemMaceOfDistortionConfig.attackSpeed;
     }
 
     @Override

--- a/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDistortionConfig.java
+++ b/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDistortionConfig.java
@@ -2,6 +2,7 @@ package org.cyclops.evilcraft.item;
 
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import org.cyclops.cyclopscore.config.ConfigurableProperty;
 import org.cyclops.cyclopscore.config.extendedconfig.ItemConfig;
 import org.cyclops.evilcraft.EvilCraft;
 
@@ -13,6 +14,9 @@ import java.util.Collection;
  *
  */
 public class ItemMaceOfDistortionConfig extends ItemConfig {
+
+    @ConfigurableProperty(category = "item", comment = "The attack speed modifier of this mace, which is added to the default player attack speed of 4.", isCommandable = true)
+    public static double attackSpeed = -3.0;
 
     public ItemMaceOfDistortionConfig() {
         super(

--- a/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDistortionConfig.java
+++ b/src/main/java/org/cyclops/evilcraft/item/ItemMaceOfDistortionConfig.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 public class ItemMaceOfDistortionConfig extends ItemConfig {
 
     @ConfigurableProperty(category = "item", comment = "The attack speed modifier of this mace, which is added to the default player attack speed of 4.", isCommandable = true)
-    public static double attackSpeed = -3.0;
+    public static double attackSpeed = -2.4;
 
     public ItemMaceOfDistortionConfig() {
         super(


### PR DESCRIPTION
Closes #1244

## Problem

The Mace of Distortion and Mace of Destruction only declared an `ATTACK_DAMAGE` attribute modifier. Without an `ATTACK_SPEED` modifier the player attribute stayed at its default of `4`, so these heavy weapons swung at 4 full-strength attacks per second, and there was no attack speed stat present for other mods/scripts to tweak.

## Changes

* `ItemMace` now also declares an `ATTACK_SPEED` modifier for the main hand, on top of the existing `ATTACK_DAMAGE` one.
* The attribute modifiers are declared by overriding `getDefaultAttributeModifiers(EquipmentSlot)` instead of Forge's `getAttributeModifiers(EquipmentSlot, ItemStack)`. Forge's default implementation of the latter delegates to the former, so behaviour is unchanged, but the modifiers now live where mods and scripting tools expect to find them.
* Attack speed is configurable per mace, via a new `attackSpeed` config option in `ItemMaceOfDistortionConfig` and `ItemMaceOfDestructionConfig` (commandable, so it can also be changed in-game).
* Removed the now-redundant `getAttributeModifiers` override in `ItemMaceOfDistortion`, which duplicated the parent implementation.

## Balance

Defaults were chosen so both maces swing noticeably slower than before, while staying competitive with top-tier vanilla weapons:

| | Speed modifier | Attacks/s | Damage | DPS | Comparable to |
|---|---|---|---|---|---|
| Mace of Distortion | -2.4 | 1.6 | 8 | 12.8 | Sword (-2.4), netherite sword is 12.8 DPS |
| Mace of Destruction | -3.0 | 1.0 | 11 | 11 | Diamond/netherite axe (-3.0), netherite axe is 10 DPS |

For reference, the previous behaviour was 4 attacks/second, i.e. 32 DPS for the Mace of Distortion and 44 DPS for the Mace of Destruction.

## Testing

`./gradlew build` passes. This repository (1.20.1) has no unit or game test infrastructure, so the change was verified by compilation and review.